### PR TITLE
migrations --> migration

### DIFF
--- a/cli/source/kubectl/approve-migration.md
+++ b/cli/source/kubectl/approve-migration.md
@@ -6,7 +6,7 @@ description: kubectl schemahero approve migration
 Mark a migration "approved" so that it will be deployed.
 
 ### Usage
-kubectl schemahero approve migrations [migration name] [flags]
+kubectl schemahero approve migration [migration name] [flags]
 
 Flag | Type |	Description
 -----|------|------------


### PR DESCRIPTION
I believe it's `kubectl schema approve migrations` (singular instead of plural).