### PR TITLE
fix tutorial kubectl psql exec command, code block

### DIFF
--- a/docs/learn/tutorial/connect-database.md
+++ b/docs/learn/tutorial/connect-database.md
@@ -23,7 +23,7 @@ After deploying this and waiting for the containers to start, you can connect to
 
 ```shell
 kubectl exec -it -n schemahero-tutorial \
-  postgresql-postgresql-0 psql -- -U airlinedb-user -d airlinedb
+  postgresql-0 -- psql -U airlinedb-user -d airlinedb
 ```
 
 If you get a message that says `error: unable to upgrade connection: container not found ("postgresql")` wait a moment and try again.
@@ -62,7 +62,7 @@ We do this by deploying custom resource to the cluster with the connection infor
 
 Create a file named `airline-db.yaml` locally, copy the following YAML in it, and then run `kubectl apply -f ./airline-db.yaml` to deploy it.
 
- ```yaml
+```yaml
 apiVersion: databases.schemahero.io/v1alpha4
 kind: Database
 metadata:


### PR DESCRIPTION
Hi there, I'm exploring SchemaHero by following the tutorials, starting step by step from https://schemahero.io/learn/tutorial/install-schemahero/

For reasons yet unclear to me, it is not possible to complete the tutorial by following the steps as-is. This PR contains a fix for one (most likely) typo, but is not the blocking step(s) for a newcomer. In interest of other newcomers, here is some more information about my setup, steps, and stops.

I have tested the steps on

## `Ubuntu 18.04.5 LTS` machine (dirty)
```
$ kubectl version  # via `nix-shell -p kubectl`
Client Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.5", GitCommit:"6b1d87acf3c8253c123756b9e61dac642678305f", GitTreeState:"archive", BuildDate:"1980-01-01T00:00:00Z", GoVersion:"go1.16.3", Compiler:"gc", Platform:"linux/amd64"}
$ kubectl schemahero version
SchemaHero 0.12.1
```

## `Ubuntu 20.04.2 LTS` machine (pristine)
```
$ kubectl version  # via sudo snap install kubectl
Client Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-16T18:16:59Z", GoVersion:"go1.16.3", Compiler:"gc", Platform:"linux/amd64"}
$ kubectl schemahero version
SchemaHero 0.12.1
```
both `SchemaHero` s are installed via `krew`. FWIW, my k8s clusters are both run using a local `k3d` setup and I did not test against a "real" k8s deployment.

Both setups behave similarly and fail the same way block and I consider them operationally equivalent. Here's a run log

```
$ k3d cluster create schemahero-tutorial-cluster
INFO[0000] Prep: Network                                
...
INFO[0012] You can now use it like this:                
kubectl config use-context k3d-schemahero-tutorial-cluster
kubectl cluster-info
$ k3d cluster list
NAME                          SERVERS   AGENTS   LOADBALANCER
schemahero-tutorial-cluster   1/1       0/0      true
$ kubectl create ns schemahero-tutorial
namespace/schemahero-tutorial created
$ kubectl apply -n schemahero-tutorial -f https://raw.githubusercontent.com/schemahero/schemahero/main/examples/tutorial/postgresql/postgresql-11.8.0.yaml
secret/postgresql created
service/postgresql-headless created
service/postgresql created
statefulset.apps/postgresql created
$ kubectl exec -it -n schemahero-tutorial postgresql-0 -- psql -U airlinedb-user -d airlinedb
Password for user airlinedb-user: 
psql (11.8)
Type "help" for help.

airlinedb=> \d
Did not find any relations.
airlinedb=> \l
                                      List of databases
   Name    |  Owner   | Encoding |   Collate   |    Ctype    |       Access privileges       
-----------+----------+----------+-------------+-------------+-------------------------------
 airlinedb | postgres | UTF8     | en_US.UTF-8 | en_US.UTF-8 | =Tc/postgres                 +
...
(4 rows)

airlinedb=> ^D\q
$ cat airline-db.yaml
apiVersion: databases.schemahero.io/v1alpha4
kind: Database
...
            key: uri
$ kubectl apply -f airline-db.yaml 
error: unable to recognize "airline-db.yaml": no matches for kind "Database" in version "databases.schemahero.io/v1alpha4"
# EASY TO FORGET
$ kubectl schemahero install
The SchemaHero operator has been upgraded in the cluster
$ kubectl apply -n schemahero-tutorial -f airline-db.yaml 
database.databases.schemahero.io/airlinedb created
$ kubectl get databases -n schemahero-tutorial
NAME        AGE
airlinedb   37s
$ cat airport-table.yaml
apiVersion: schemas.schemahero.io/v1alpha4
kind: Table
metadata:
  name: airport
  namespace: schemahero-tutorial
...
$ kubectl apply -n schemahero-tutorial -f airport-table.yaml 
table.schemas.schemahero.io/airport created
$ kubectl get migrations -n schemahero-tutorial
No resources found in schemahero-tutorial namespace.
$ kubectl get databases -n schemahero-tutorial
NAME        AGE
airlinedb   6m39s
```

As shown, following the steps gets blocked at the migration part. I realize this probably warrants a separate issue but it could also be something trivial like a typo somewhere in the tutorial.

Thanks for your work.